### PR TITLE
Changes on position of mrcnn import

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -34,7 +34,6 @@ import datetime
 import numpy as np
 import skimage.draw
 import cv2
-from mrcnn.visualize import display_instances
 import matplotlib.pyplot as plt
 
 # Root directory of the project
@@ -42,6 +41,7 @@ ROOT_DIR = os.path.abspath("../../")
 
 # Import Mask RCNN
 sys.path.append(ROOT_DIR)  # To find local version of the library
+from mrcnn.visualize import display_instances
 from mrcnn.config import Config
 from mrcnn import model as modellib, utils
 


### PR DESCRIPTION
I suppose that a requirement to run this project is to have mrcnn directory from https://github.com/matterport/Mask_RCNN. Before appending the ROOT_DIR to sys, there's no way I could make the "from mrcnn.visualize import display_instances" line work. 